### PR TITLE
fix: create a response description if one is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
+        "@readme/http-status-codes": "^7.2.0",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "3.2.0",
         "lodash.camelcase": "^4.3.0",
@@ -1076,6 +1077,11 @@
         "eslint": "^8.0.0",
         "prettier": "^2.0.2"
       }
+    },
+    "node_modules/@readme/http-status-codes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.2.0.tgz",
+      "integrity": "sha512-/dBh9qw3QhJYqlGwt2I+KUP/lQ6nytdCx3aq+GpMUhibLHF3O7fwoowNcTwlbnwtyJ+TJYTIIrp3oVUlRNx3fA=="
     },
     "node_modules/@testing-library/dom": {
       "version": "8.20.0",
@@ -8257,6 +8263,11 @@
         "eslint-plugin-unicorn": "^46.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
+    },
+    "@readme/http-status-codes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/http-status-codes/-/http-status-codes-7.2.0.tgz",
+      "integrity": "sha512-/dBh9qw3QhJYqlGwt2I+KUP/lQ6nytdCx3aq+GpMUhibLHF3O7fwoowNcTwlbnwtyJ+TJYTIIrp3oVUlRNx3fA=="
     },
     "@testing-library/dom": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "release": "npx conventional-changelog-cli -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
   "dependencies": {
+    "@readme/http-status-codes": "^7.2.0",
     "js-yaml": "^4.1.0",
     "jsonc-parser": "3.2.0",
     "lodash.camelcase": "^4.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const {
   promises: { writeFile, readFile },
 } = require('fs');
 
+const { getStatusCodeMessage } = require('@readme/http-status-codes');
 const { dump } = require('js-yaml');
 const jsonc = require('jsonc-parser');
 const camelCase = require('lodash.camelcase');
@@ -550,6 +551,16 @@ function parseResponseFromExamples(responses, responseHeaders) {
     (statusMap, { name, code, status: description, header, body, _postman_previewlanguage: language }) => {
       if (code === undefined) {
         code = 'default';
+      }
+
+      // The OpenAPI spec requires that `description` be present on responses with content so
+      // we'll make it match the message that cooresponds to the HTTP status code.
+      if (!description) {
+        try {
+          description = getStatusCodeMessage({ code });
+        } catch (err) {
+          description = code;
+        }
       }
 
       if (code in statusMap) {

--- a/test/resources/output/ResponsesWithoutHTTPStatusCode.yml
+++ b/test/resources/output/ResponsesWithoutHTTPStatusCode.yml
@@ -24,6 +24,7 @@ paths:
                 avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg
       responses:
         default:
+          description: default
           headers:
             Server:
               schema:

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,1 @@
+declare module '@readme/http-status-codes';


### PR DESCRIPTION
| 🚥 Fixes CX-268 |
| :---------------- |

## 🧰 Changes

If a Postman response does not have a `description` we'll now create one that matches the message of the corresponding HTTP Status Code. For example if the code is `404` then the `description` will be "Not Found".