### PR TITLE
fix: when unable to get the status code description, set the code to string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -559,7 +559,7 @@ function parseResponseFromExamples(responses, responseHeaders) {
         try {
           description = getStatusCodeMessage({ code });
         } catch (err) {
-          description = code;
+          description = code.toString();
         }
       }
 


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

When an error occurs in the description default behavior, set the code to string

## 🧬 QA & Testing

When a collection has some bad formatted examples, and this error is reached, the validator is complaining because the 'description must be a string' rather than a number'.

<img width="636" alt="image" src="https://github.com/readmeio/postman-to-openapi/assets/25979809/effd41c0-a88b-4ab6-8e62-3498ef575fae">
